### PR TITLE
Use benchmark/ips for better performance comparison

### DIFF
--- a/benchmarks/arguments_to_filter.rb
+++ b/benchmarks/arguments_to_filter.rb
@@ -14,7 +14,7 @@
 
 $LOAD_PATH << File.expand_path("../../lib", __FILE__)
 require 'transducers'
-require 'benchmark'
+require 'benchmark/ips'
 
 class Even
   def call(n) n.even? end
@@ -23,36 +23,31 @@ end
 e = 1.upto(1000)
 a = e.to_a
 
-times = 1000
-
 T = Transducers
 
-Benchmark.benchmark do |bm|
-  {"enum" => e, "array" => a}.each do |label, coll|
-    puts "filter with object (#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          T.transduce(T.filter(Even.new), :<<, [], coll)
-        end
+Benchmark.ips do |bm|
+  { "enum" => e, "array" => a }.each do |label, coll|
+    bm.report("filter with object (#{label})") do |times|
+      i = 0
+      while i < times
+        T.transduce(T.filter(Even.new), :<<, [], coll)
+        i += 1
       end
     end
 
-    puts "filter with Symbol(#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          T.transduce(T.filter(:even?), :<<, [], coll)
-        end
+    bm.report("filter with Symbol(#{label})") do |times|
+      i = 0
+      while i < times
+        T.transduce(T.filter(:even?), :<<, [], coll)
+        i += 1
       end
     end
 
-    puts "filter with block (#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          T.transduce(T.filter {|n| n.even?}, :<<, [], coll)
-        end
+    bm.report("filter with block (#{label})") do |times|
+      i = 0
+      while i < times
+        T.transduce(T.filter { |n| n.even? }, :<<, [], coll)
+        i += 1
       end
     end
   end

--- a/benchmarks/arguments_to_map.rb
+++ b/benchmarks/arguments_to_map.rb
@@ -14,13 +14,12 @@
 
 $LOAD_PATH << File.expand_path("../../lib", __FILE__)
 require 'transducers'
-require 'benchmark'
+require 'benchmark/ips'
 
 class Inc
   def call(n) n + 1 end
 end
 
-times = 100
 size  = 1000
 
 e = 1.upto(size)
@@ -28,32 +27,31 @@ a = e.to_a
 
 T = Transducers
 
-Benchmark.benchmark do |bm|
-  {"enum" => e, "array" => a}.each do |label, coll|
-    puts "map with object (#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          T.transduce(T.map(Inc.new), :<<, [], coll)
-        end
+Benchmark.ips do |bm|
+  { "enum" => e, "array" => a }.each do |label, coll|
+    bm.report("map with object (#{label})") do |times|
+      i = 0
+      while i < times
+        T.transduce(T.map(Inc.new), :<<, [], coll)
+        i += 1
       end
     end
 
-    puts "map with Symbol(#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          T.transduce(T.map(:succ), :<<, [], coll)
-        end
+
+    bm.report("map with Symbol(#{label})") do |times|
+      i = 0
+      while i < times
+        T.transduce(T.map(:succ), :<<, [], coll)
+        i += 1
       end
     end
 
-    puts "map with block (#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          T.transduce(T.map {|n| n + 1}, :<<, [], coll)
-        end
+
+    bm.report("map with block (#{label})") do |times|
+      i = 0
+      while i < times
+        T.transduce(T.map { |n| n + 1 }, :<<, [], coll)
+        i += 1
       end
     end
   end

--- a/benchmarks/transducers_v_ruby_iterators.rb
+++ b/benchmarks/transducers_v_ruby_iterators.rb
@@ -14,7 +14,7 @@
 
 $LOAD_PATH << File.expand_path("../../lib", __FILE__)
 require 'transducers'
-require 'benchmark'
+require 'benchmark/ips'
 
 class Inc
   def call(n) n + 1 end
@@ -24,135 +24,132 @@ class Even
   def call(n) n.even? end
 end
 
-map_inc         = Transducers.map(Inc.new)
-filter_even      = Transducers.filter(Even.new)
+map_inc             = Transducers.map(Inc.new)
+filter_even         = Transducers.filter(Even.new)
 map_inc_filter_even = Transducers.compose(map_inc, filter_even)
 e = 1.upto(1000)
 a = e.to_a
 
-times = 100
-
 T = Transducers
 
-Benchmark.benchmark do |bm|
-  {"enum" => e, "array" => a}.each do |label, coll|
-    puts "select (#{label})"
-
-    3.times do
-      bm.report do
-        times.times do
-          coll.select {|n| n.even?}
-        end
+Benchmark.ips do |bm|
+  { "enum" => e, "array" => a }.each do |label, coll|
+    bm.report("select (#{label})") do |times|
+      i = 0
+      while i < times
+        coll.select { |n| n.even? }
+        i += 1
       end
     end
 
-    puts "filter (#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          T.transduce(filter_even, :<<, [], coll)
-        end
+    bm.report("filter (#{label})") do |times|
+      i = 0
+      while i < times
+        T.transduce(filter_even, :<<, [], coll)
+        i += 1
       end
     end
-
-    puts
-
-    puts "map (#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          coll.map {|n| n + 1}
-        end
-      end
-    end
-
-    puts "map (#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          T.transduce(map_inc, :<<, [], coll)
-        end
-      end
-    end
-
-    puts
-
-    puts "map + select (#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          coll.
-            map    {|n| n + 1}.
-            select {|n| n.even?}
-        end
-      end
-    end
-
-    puts "map + filter (#{label})"
-    3.times do
-      bm.report do
-        times.times do
-          T.transduce(map_inc_filter_even, :<<, [], coll)
-        end
-      end
-    end
-
-    puts
   end
+
+  bm.compare!
+end
+
+
+Benchmark.ips do |bm|
+  { "enum" => e, "array" => a }.each do |label, coll|
+    bm.report("map (#{label})") do |times|
+      i = 0
+      while i < times
+        coll.map { |n| n + 1 }
+        i += 1
+      end
+    end
+
+    bm.report("T. map (#{label})") do |times|
+      i = 0
+      while i < times
+        T.transduce(map_inc, :<<, [], coll)
+        i += 1
+      end
+    end
+  end
+
+  bm.compare!
+end
+
+Benchmark.ips do |bm|
+  { "enum" => e, "array" => a }.each do |label, coll|
+    bm.report("map + select (#{label})") do |times|
+      i = 0
+      while i < times
+        coll.
+          map { |n| n + 1 }.
+          select { |n| n.even? }
+        i += 1
+      end
+    end
+
+    bm.report("map + filter (#{label})") do |times|
+      i = 0
+      while i < times
+        T.transduce(map_inc_filter_even, :<<, [], coll)
+        i += 1
+      end
+    end
+  end
+
+  bm.compare!
 end
 
 __END__
 
-select (enum)
-   0.010000   0.000000   0.010000 (  0.008299)
-   0.010000   0.000000   0.010000 (  0.007843)
-   0.000000   0.000000   0.000000 (  0.007821)
-filter (enum)
-   0.020000   0.000000   0.020000 (  0.017747)
-   0.020000   0.000000   0.020000 (  0.019915)
-   0.020000   0.000000   0.020000 (  0.019416)
+Calculating -------------------------------------
+       select (enum)     1.005k i/100ms
+       filter (enum)   315.000  i/100ms
+      select (array)     1.218k i/100ms
+      filter (array)   308.000  i/100ms
+-------------------------------------------------
+       select (enum)     10.101k (± 2.0%) i/s -     51.255k
+       filter (enum)      3.185k (± 3.1%) i/s -     16.065k
+      select (array)     12.824k (± 7.9%) i/s -     64.554k
+      filter (array)      3.314k (± 2.0%) i/s -     16.632k
 
-map (enum)
-   0.010000   0.000000   0.010000 (  0.008053)
-   0.010000   0.000000   0.010000 (  0.007952)
-   0.010000   0.000000   0.010000 (  0.009550)
-map (enum)
-   0.020000   0.000000   0.020000 (  0.021479)
-   0.020000   0.000000   0.020000 (  0.020805)
-   0.020000   0.000000   0.020000 (  0.023205)
+Comparison:
+      select (array):    12824.3 i/s
+       select (enum):    10101.5 i/s - 1.27x slower
+      filter (array):     3313.8 i/s - 3.87x slower
+       filter (enum):     3184.7 i/s - 4.03x slower
 
-map + select (enum)
-   0.010000   0.000000   0.010000 (  0.015156)
-   0.020000   0.000000   0.020000 (  0.016545)
-   0.010000   0.010000   0.020000 (  0.019388)
-map + filter (enum)
-   0.030000   0.000000   0.030000 (  0.026530)
-   0.030000   0.000000   0.030000 (  0.025563)
-   0.020000   0.000000   0.020000 (  0.027893)
+Calculating -------------------------------------
+          map (enum)     1.002k i/100ms
+       T. map (enum)   287.000  i/100ms
+         map (array)     1.431k i/100ms
+      T. map (array)   278.000  i/100ms
+-------------------------------------------------
+          map (enum)     10.249k (± 3.2%) i/s -     52.104k
+       T. map (enum)      2.757k (± 2.7%) i/s -     13.776k
+         map (array)     13.956k (± 3.7%) i/s -     70.119k
+      T. map (array)      2.817k (± 3.1%) i/s -     14.178k
 
-select (array)
-   0.010000   0.000000   0.010000 (  0.006520)
-   0.010000   0.000000   0.010000 (  0.006570)
-   0.000000   0.000000   0.000000 (  0.007032)
-filter (array)
-   0.020000   0.000000   0.020000 (  0.022639)
-   0.030000   0.000000   0.030000 (  0.023813)
-   0.020000   0.000000   0.020000 (  0.022440)
+Comparison:
+         map (array):    13956.1 i/s
+          map (enum):    10248.6 i/s - 1.36x slower
+      T. map (array):     2817.3 i/s - 4.95x slower
+       T. map (enum):     2756.9 i/s - 5.06x slower
 
-map (array)
-   0.010000   0.000000   0.010000 (  0.005880)
-   0.000000   0.000000   0.000000 (  0.005613)
-   0.010000   0.000000   0.010000 (  0.005294)
-map (array)
-   0.020000   0.000000   0.020000 (  0.024443)
-   0.030000   0.000000   0.030000 (  0.023856)
-   0.020000   0.000000   0.020000 (  0.024172)
+Calculating -------------------------------------
+ map + select (enum)   550.000  i/100ms
+ map + filter (enum)   219.000  i/100ms
+map + select (array)   659.000  i/100ms
+map + filter (array)   222.000  i/100ms
+-------------------------------------------------
+ map + select (enum)      5.647k (± 1.8%) i/s -     28.600k
+ map + filter (enum)      2.208k (± 1.6%) i/s -     11.169k
+map + select (array)      6.673k (± 3.4%) i/s -     33.609k
+map + filter (array)      2.272k (± 2.4%) i/s -     11.544k
 
-map + select (array)
-   0.010000   0.000000   0.010000 (  0.012158)
-   0.010000   0.000000   0.010000 (  0.012061)
-   0.020000   0.000000   0.020000 (  0.014131)
-map + filter (array)
-   0.020000   0.000000   0.020000 (  0.026898)
-   0.030000   0.000000   0.030000 (  0.025745)
-   0.030000   0.000000   0.030000 (  0.028196)
+Comparison:
+map + select (array):     6673.4 i/s
+ map + select (enum):     5646.8 i/s - 1.18x slower
+map + filter (array):     2271.9 i/s - 2.94x slower
+ map + filter (enum):     2208.1 i/s - 3.02x slower


### PR DESCRIPTION
Hi,

I've replaced the benchmark logic with `benchmark-ips` gem that is IMO much better for comparing such fast methods. Also I replaced the times block loop with the (by `benchmark-ips`) recommended `while` that has lower overhead.

Results on my machine (Ubuntu / ruby 2.2.0)

```
Calculating -------------------------------------
       select (enum)     1.005k i/100ms
       filter (enum)   315.000  i/100ms
      select (array)     1.218k i/100ms
      filter (array)   308.000  i/100ms
-------------------------------------------------
       select (enum)     10.101k (± 2.0%) i/s -     51.255k
       filter (enum)      3.185k (± 3.1%) i/s -     16.065k
      select (array)     12.824k (± 7.9%) i/s -     64.554k
      filter (array)      3.314k (± 2.0%) i/s -     16.632k

Comparison:
      select (array):    12824.3 i/s
       select (enum):    10101.5 i/s - 1.27x slower
      filter (array):     3313.8 i/s - 3.87x slower
       filter (enum):     3184.7 i/s - 4.03x slower

Calculating -------------------------------------
          map (enum)     1.002k i/100ms
       T. map (enum)   287.000  i/100ms
         map (array)     1.431k i/100ms
      T. map (array)   278.000  i/100ms
-------------------------------------------------
          map (enum)     10.249k (± 3.2%) i/s -     52.104k
       T. map (enum)      2.757k (± 2.7%) i/s -     13.776k
         map (array)     13.956k (± 3.7%) i/s -     70.119k
      T. map (array)      2.817k (± 3.1%) i/s -     14.178k

Comparison:
         map (array):    13956.1 i/s
          map (enum):    10248.6 i/s - 1.36x slower
      T. map (array):     2817.3 i/s - 4.95x slower
       T. map (enum):     2756.9 i/s - 5.06x slower

Calculating -------------------------------------
 map + select (enum)   550.000  i/100ms
 map + filter (enum)   219.000  i/100ms
map + select (array)   659.000  i/100ms
map + filter (array)   222.000  i/100ms
-------------------------------------------------
 map + select (enum)      5.647k (± 1.8%) i/s -     28.600k
 map + filter (enum)      2.208k (± 1.6%) i/s -     11.169k
map + select (array)      6.673k (± 3.4%) i/s -     33.609k
map + filter (array)      2.272k (± 2.4%) i/s -     11.544k

Comparison:
map + select (array):     6673.4 i/s
 map + select (enum):     5646.8 i/s - 1.18x slower
map + filter (array):     2271.9 i/s - 2.94x slower
 map + filter (enum):     2208.1 i/s - 3.02x slower
```
